### PR TITLE
Add Nim and Python fetches + Update benchmarks

### DIFF
--- a/nim/nim.cfg
+++ b/nim/nim.cfg
@@ -1,0 +1,33 @@
+# Is this cheating? I hope not :P
+@if release or quick:
+  obj_checks:off
+  field_checks:off
+  range_checks:off
+  bound_checks:off
+  overflow_checks:off
+  assertions:off
+  stacktrace:off
+  linetrace:off
+  debugger:off
+  line_dir:off
+  dead_code_elim:on
+  @if nimHasNilChecks:
+    nilchecks:off
+  @end
+@end
+
+@if release:
+  opt:speed
+@end
+
+gcc.options.speed = "-O3 -fno-strict-aliasing"
+gcc.options.size = "-Os"
+@if windows:
+  gcc.options.debug = "-g3 -O0 -gdwarf-3"
+@else:
+  gcc.options.debug = "-g3 -O0"
+@end
+gcc.c.options.speed = "-O3 -fno-strict-aliasing"
+gcc.c.options.size = "-Os"
+gcc.c.options.debug = "-g3 -O0"
+

--- a/nim/src/tinierfetch_nim.nim
+++ b/nim/src/tinierfetch_nim.nim
@@ -1,0 +1,18 @@
+import std/[os]
+
+when defined(color):
+  const COLORS: array[0..3, string] = [
+    "31", "32", "33", "34"
+  ]
+
+proc main {.inline.} =
+  for env in ["USER", "SHELL", "TERM", "LANG"]:
+    when defined(color):
+      echo("\033[0;m " & env & ":\033[0m " & getEnv(env) & "")
+    else:
+      echo(env & ": " & getEnv(env))
+
+  echo("\x1B[35mcolors: \x1B[0m\x1B[41m \x1B[42m \x1B[43m \x1B[44m \x1B[45m \x1B[0m")
+
+when isMainModule:
+  main()

--- a/nim/tinierfetch_nim.nimble
+++ b/nim/tinierfetch_nim.nimble
@@ -1,0 +1,16 @@
+# Package
+
+version       = "0.1.0"
+author        = "xTrayambak"
+description   = "Tinierfetch, written in the Nim programming language"
+license       = "MIT"
+srcDir        = "src"
+bin           = @["tinierfetch_nim"]
+
+
+# Dependencies
+
+requires "nim >= 1.6.14"
+
+task speed, "Built with all optimization flags*":
+  exec "nim c -o:../bin/tinierfetch-nim -d:color -d:danger -d:release -d:quick src/tinierfetch_nim.nim"

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 mkdir -p bin/
+rm -rf bin/*
 
 root_dir=$(pwd)
 
@@ -10,25 +11,47 @@ cd go/
 go build -ldflags="-s -w" -o ../bin/tinierfetch-go main.go
 cd $root_dir
 
-# 2. Build and copy Rust binary
+# 2. Build and copy Nim binary
+echo "Building and copying Nim binaries..."
+cd nim/
+nimble speed --silent
+cd $root_dir
+
+# 3. Build and copy Rust binary
 echo "Building and copying Rust binary..."
 cd rs/
 cargo build --release
 cp target/release/tinierfetch-rs ../bin/ -vf
 cd $root_dir
 
-# 3. Build and copy C++ binaries
+# 4. Build and copy C++ binaries
 echo "Building and copying C++ binaries..."
 cd cpp/
 make clean && make all &&
 cp fetch_size fetch_speed ../bin/ -vf
 cd $root_dir
 
-# 4. Display binary sizes
-echo "Binary Sizes:"
+# 5. Copy Python script
+# echo "Copying Python script"
+# cd py/
+# cp tinierfetch-py.py ../bin/ -vf
+# chmod +x ../bin/tinierfetch-py.py
+# cd $root_dir
+
+# 6. Display binary sizes
+echo "Binary/Script Sizes:"
 ls -lh bin/*
 
-# 5. Benchmark binary speeds
+# 7. Benchmark binary speeds
 echo "Benchmarking binary speeds..."
-hyperfine -N --warmup 10000 'bin/tinierfetch-go' 'bin/tinierfetch-rs' 'bin/tinierfetch-cpp-size' 'bin/tinierfetch-cpp-speed' --export-markdown markdown.md
-
+s1=""
+cd bin/
+rm markdown.md
+for file in *; do
+if [ -f "$file" ]; then
+s1=$s1$' bin/'$bins$file
+fi
+done
+cd ..
+echo $s1
+hyperfine -N --warmup 10000 $s1 --export-markdown markdown.md

--- a/py/tinierfetch-py.py
+++ b/py/tinierfetch-py.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import sys, os
+
+if len(sys.argv) > 1:
+    COLOR = sys.argv[1] == "color"
+else:
+    COLOR = True
+
+def main():
+    for env in ["USER", "SHELL", "TERM", "LANG"]:
+        if COLOR:
+            sys.stdout.write("\033[0;" + "m" + env + ":\033[0m" + os.environ.get(env) + "\n")
+        else:
+            sys.stdout.write(env + ": " + os.environ.get(env))
+
+    sys.stdout.write("\x1B[35mcolors: \x1B[0m\x1B[41m \x1B[42m \x1B[43m \x1B[44m \x1B[45m \x1B[0m" + "\n")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Add benchmarks for the Nim programming language and Python.
- Python is disabled by default because it takes AGES to complete (8-10 minutes on my CPU).
- Updated prepare.sh to run everything inside `bin/`, not just a list of binaries. This makes adding new benchmarks easier.
